### PR TITLE
Caches complete test runs on the project/test_runs index page

### DIFF
--- a/lib/hobson.rb
+++ b/lib/hobson.rb
@@ -31,6 +31,7 @@ module Hobson
   autoload :Server,       'hobson/server'
   autoload :Worker,       'hobson/worker'
   autoload :CI,           'hobson/ci'
+  autoload :Cache,        'hobson/cache'
 
   def root
     @root ||= Pathname.new ENV['HOBSON_ROOT'] ||= Dir.pwd

--- a/lib/hobson/cache.rb
+++ b/lib/hobson/cache.rb
@@ -1,0 +1,39 @@
+class Hobson::Cache
+
+  @@simple_cache = {}
+
+  class << self
+
+    def read key
+      @@simple_cache[key]
+    end
+
+    def write key, value
+      @@simple_cache[key] = value
+    end
+
+    def delete key
+      @@simple_cache.delete key
+    end
+
+    def has_key? key
+      @@simple_cache.has_key? key
+    end
+
+    def fetch key, &block
+      has_key?(key) ? read(key) : write(key, block.call)
+    end
+
+    def clear
+      @@simple_cache = {}
+    end
+
+    def build_key model, modifier=nil
+      key = model.respond_to?(:id) ? "#{model.class.name}-#{model.id}" : model
+      key << "-#{modifier}" if modifier.present?
+      key
+    end
+
+  end
+
+end

--- a/lib/hobson/server.rb
+++ b/lib/hobson/server.rb
@@ -190,6 +190,7 @@ class Hobson::Server < Sinatra::Base
   # delete
   delete "/projects/:project_name/test_runs/:test_run_id" do
     test_run.delete!
+    Hobson::Cache.delete Hobson::Cache.build_key(test_run, :list)
     redirect test_runs_path
   end
 

--- a/lib/hobson/server/views/projects/test_runs/_list.haml
+++ b/lib/hobson/server/views/projects/test_runs/_list.haml
@@ -14,24 +14,8 @@
       %th Pending
   %tbody
     - test_runs.sort_by{|t| t.created_at || Time.now }.reverse.each do |test_run|
-      %tr{:class => test_run.status.gsub(' ','-')}
-        %td
-          %form{:id => "delete#{test_run.id}", :action => test_run_path(test_run), :method => 'post'}
-            %input{:type=>:hidden, :name=>'_method', :value=>'delete'}
-            %a{:href => "javascript: $('#delete#{test_run.id}').submit()"} X
-        %td= test_run.status
-        %td
-          %a{:href => test_run_path(test_run)}= test_run.id
-        %td
-          %a{:href => sha_url(test_run.project.origin, test_run.sha)}= test_run.sha[0..7]
-        %td= test_run.requestor || 'unknown'
-        %td= distance_of_time_in_words(Time.now - test_run.created_at) + ' ago' if test_run.created_at.present?
-        %td= test_run.tests.find_all(&:waiting?).count
-        %td= test_run.tests.map{|t| t.tries > 0 ? t.tries - 1 : 0}.sum
-        %td= test_run.tests.find_all(&:fail?).count
-        %td= test_run.tests.find_all(&:pass?).count
-        %td= test_run.tests.find_all(&:pending?).count
-        %td
-          - max = test_run.tests.size
-          - value = test_run.aborted? ? max : test_run.tests.reject(&:waiting?).size
-          %progress{:value => value, :max => max}
+      - cache_key = Hobson::Cache.build_key test_run, :list
+      - if Hobson::Cache.has_key?(cache_key)
+        = Hobson::Cache.read(cache_key)
+      - else
+        = render :partial => :'projects/test_runs/test_run', :object => test_run, :locals => {:cache_key => cache_key}

--- a/lib/hobson/server/views/projects/test_runs/_test_run.html.haml
+++ b/lib/hobson/server/views/projects/test_runs/_test_run.html.haml
@@ -1,0 +1,24 @@
+= content = capture do
+  %tr{:class => test_run.status.gsub(' ','-')}
+  %td
+    %form{:id => "delete#{test_run.id}", :action => test_run_path(test_run), :method => 'post'}
+      %input{:type=>:hidden, :name=>'_method', :value=>'delete'}
+      %a{:href => "javascript: $('#delete#{test_run.id}').submit()"} X
+  %td= test_run.status
+  %td
+    %a{:href => test_run_path(test_run)}= test_run.id
+  %td
+    %a{:href => sha_url(test_run.project.origin, test_run.sha)}= test_run.sha[0..7]
+  %td= test_run.requestor || 'unknown'
+  %td= distance_of_time_in_words(Time.now - test_run.created_at) + ' ago' if test_run.created_at.present?
+  %td= test_run.tests.find_all(&:waiting?).count
+  %td= test_run.tests.map{|t| t.tries > 0 ? t.tries - 1 : 0}.sum
+  %td= test_run.tests.find_all(&:fail?).count
+  %td= test_run.tests.find_all(&:pass?).count
+  %td= test_run.tests.find_all(&:pending?).count
+  %td
+    - max = test_run.tests.size
+    - value = test_run.aborted? ? max : test_run.tests.reject(&:waiting?).size
+    %progress{:value => value, :max => max}
+
+- Hobson::Cache.write cache_key, content if test_run.complete?

--- a/spec/hobson/cache_spec.rb
+++ b/spec/hobson/cache_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Hobson::Cache do
+
+  it 'should respond to write and read' do
+    Hobson::Cache.write(:a, :b).should == :b
+    Hobson::Cache.read(:a).should == :b
+  end
+
+  it 'should respond to delete' do
+    Hobson::Cache.write(:a, :b).should == :b
+    Hobson::Cache.delete(:a).should == :b
+  end
+
+  it 'should respond to fetch' do
+    Hobson::Cache.fetch(:a) { :b }.should == :b
+    Hobson::Cache.read(:a).should == :b
+    Hobson::Cache.fetch(:a) { :c }.should == :b
+    Hobson::Cache.delete(:a).should == :b
+    Hobson::Cache.fetch(:a) { :c }.should == :c
+  end
+
+  it 'should respond to has_key?' do
+    Hobson::Cache.write(:a, :b).should == :b
+    Hobson::Cache.has_key?(:a).should be_true
+    Hobson::Cache.has_key?(:NOT_FOUND).should be_false
+  end
+
+  it 'should build the proper cache key for models and other objects' do
+    Hobson::Cache.build_key(Hobson::Project::TestRun.new(nil, 1)).should == "Hobson::Project::TestRun-1"
+    Hobson::Cache.build_key(Hobson::Project::TestRun.new(nil, 2), :specific).should == "Hobson::Project::TestRun-2-specific"
+    Hobson::Cache.build_key(:abc).should == :abc
+    Hobson::Cache.build_key("123", :ab).should == "123-ab"
+  end
+
+  it 'should respond to clear' do
+    Hobson::Cache.write(:a, :b).should == :b
+    Hobson::Cache.has_key?(:a).should be_true
+    Hobson::Cache.clear
+    Hobson::Cache.has_key?(:a).should be_false
+  end
+
+end


### PR DESCRIPTION
I did this so the index page doesn't calculate completed runs every time,
as that checks redis multiple times.

To accomplish this, I built a really simple in-memory cache to store any data.
You could easily change it to redis, however I thought an in memory cache
was faster and it shouldn't take up too much space.

BTW, I have no clue if this actually works. The specs do pass. But I couldn't get the web server to run, and didn't see any specs for the web server to test it against. I'm not super familiar with sinatra's render signature, so I based it off rails standard options. That should be looked at. And I don't know if the capture block works either. I believe haml implements capture too, so it might be ok. But the general idea, I believe, is there.

Thanks dude.
